### PR TITLE
Move OBJECT_ATTRIBUTES structs to the WDK

### DIFF
--- a/generation/WDK/manual/Foundation.cs
+++ b/generation/WDK/manual/Foundation.cs
@@ -3,7 +3,6 @@ using System.Runtime.InteropServices;
 
 using Windows.Win32.Foundation;
 using Windows.Win32.Foundation.Metadata;
-using Windows.Win32.System.IO;
 
 namespace Windows.Wdk.Foundation;
 

--- a/generation/WDK/manual/Foundation.cs
+++ b/generation/WDK/manual/Foundation.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Runtime.InteropServices;
+
+using Windows.Win32.Foundation;
+using Windows.Win32.Foundation.Metadata;
+using Windows.Win32.System.IO;
+
+namespace Windows.Wdk.Foundation;
+
+public unsafe partial struct OBJECT_ATTRIBUTES
+{
+    [NativeTypeName("ULONG")]
+    public uint Length;
+
+    [NativeTypeName("HANDLE")]
+    public IntPtr RootDirectory;
+
+    [NativeTypeName("PUNICODE_STRING")]
+    [Const]
+    public UNICODE_STRING* ObjectName;
+
+    [NativeTypeName("ULONG")]
+    public uint Attributes;
+
+    [NativeTypeName("PVOID")]
+    [Const]
+    public void* SecurityDescriptor;
+
+    [NativeTypeName("PVOID")]
+    [Const]
+    public void* SecurityQualityOfService;
+}
+
+public partial struct OBJECT_ATTRIBUTES32
+{
+    [NativeTypeName("ULONG")]
+    public uint Length;
+
+    [NativeTypeName("ULONG")]
+    public uint RootDirectory;
+
+    [NativeTypeName("ULONG")]
+    public uint ObjectName;
+
+    [NativeTypeName("ULONG")]
+    public uint Attributes;
+
+    [NativeTypeName("ULONG")]
+    [Const]
+    public uint SecurityDescriptor;
+
+    [NativeTypeName("ULONG")]
+    [Const]
+    public uint SecurityQualityOfService;
+}
+
+public partial struct OBJECT_ATTRIBUTES64
+{
+    [NativeTypeName("ULONG")]
+    public uint Length;
+
+    [NativeTypeName("ULONG64")]
+    public ulong RootDirectory;
+
+    [NativeTypeName("ULONG64")]
+    public ulong ObjectName;
+
+    [NativeTypeName("ULONG")]
+    public uint Attributes;
+
+    [NativeTypeName("ULONG64")]
+    [Const]
+    public ulong SecurityDescriptor;
+
+    [NativeTypeName("ULONG64")]
+    [Const]
+    public ulong SecurityQualityOfService;
+}

--- a/scripts/ChangesSinceLastRelease.txt
+++ b/scripts/ChangesSinceLastRelease.txt
@@ -1,0 +1,6 @@
+# Added OBJECT_ATTRIBUTES from the SDK.
+Windows.Wdk.Foundation.OBJECT_ATTRIBUTES added
+Windows.Wdk.Foundation.OBJECT_ATTRIBUTES32 added
+Windows.Wdk.Foundation.OBJECT_ATTRIBUTES64 added
+Windows.Wdk.Graphics.Direct3D.D3DKMT_OPENNTHANDLEFROMNAME.pObjAttrib...Windows.Win32.Foundation.OBJECT_ATTRIBUTES* => Windows.Wdk.Foundation.OBJECT_ATTRIBUTES*
+Windows.Wdk.Graphics.Direct3D.D3DKMT_OPENSYNCOBJECTNTHANDLEFROMNAME.pObjAttrib...Windows.Win32.Foundation.OBJECT_ATTRIBUTES* => Windows.Wdk.Foundation.OBJECT_ATTRIBUTES*


### PR DESCRIPTION
Includes the WDK side of https://github.com/microsoft/win32metadata/issues/1565.

The changes can be merged once a new SDK metadata update is published and ingested.