### PR TITLE
Migrate Azure build pipeline to OneBranch

### DIFF
--- a/AzurePipelinesTemplates/wdkmetadata-checkout.yml
+++ b/AzurePipelinesTemplates/wdkmetadata-checkout.yml
@@ -1,0 +1,11 @@
+parameters:
+- name: "RepoDirectory"
+  type: string
+  default: "wdkmetadata"
+
+steps:
+- checkout: wdkmetadata
+  path: s/${{ parameters.RepoDirectory }}
+  lfs: false
+  displayName: Checkout wdkmetadata from github
+  submodules: recursive

--- a/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
+++ b/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
@@ -5,9 +5,6 @@ parameters:
 - name: "RepoDirectory"
   type: string
   default: "wdkmetadata"
-- name: BuildConfiguration
-  type: string
-  default: Release
 - name: OfficialBuild
   type: boolean
   default: false
@@ -137,7 +134,8 @@ stages:
       displayName: '🔒 Onebranch Signing for Binaries in Metadata package'
       condition: eq(${{ parameters.OfficialBuild }}, 'true')
       inputs:
-        command: sign
+        command: 'sign'
+        cp_code: 'CP-230012'
         signing_profile: external_distribution
         files_to_sign: 'Windows.Wdk.winmd'
         search_root: $(Build.SourcesDirectory)\${{ parameters.RepoDirectory }}\bin
@@ -159,6 +157,7 @@ stages:
       condition: eq(${{ parameters.OfficialBuild }}, 'true')
       inputs:
         command: sign
+        cp_code: 'CP-401405'
         signing_profile: external_distribution
         files_to_sign: '**/*.nupkg'
         search_root: $(OutputPackagesDir)

--- a/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
+++ b/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
@@ -1,0 +1,287 @@
+parameters:
+- name: "PipelineType"
+  type: string
+  default: "PullRequest"
+- name: "RepoDirectory"
+  type: string
+  default: "win32metadata"
+- name: BuildConfiguration
+  type: string
+  default: Release
+
+stages:
+- stage: scrape
+  displayName: "Scrape"
+  jobs:
+  - job: scrape
+    strategy:
+      matrix:
+        x86:
+          arch: 'x86'
+        x64:
+          arch: 'x64'
+        arm64:
+          arch: 'arm64'
+    displayName: "Scrape headers"
+    timeoutInMinutes: 60
+    variables:
+      ob_outputDirectory: '${{parameters.RepoDirectory}}\generation\WinSDK\obj'
+      ob_artifactBaseName: 'generated'
+      ob_artifactSuffix: '_$(arch)'
+      ob_sdl_binskim_break: true # https://aka.ms/obpipelines/sdl
+    pool:
+      type: windows
+    steps:
+    - template: win32metadata-checkout.yml
+      parameters:
+        RepoDirectory: ${{ parameters.RepoDirectory }}
+
+    - task: UseDotNet@2
+      displayName: ⚙ Install .NET SDK
+      inputs:
+        packageType: sdk
+        useGlobalJson: true
+
+    # TODO - this no longer sets an Azure Devops pipeline build number, OneBranch has a different way of doing that
+    - task: PowerShell@2
+      displayName: Set build version
+      condition: eq(variables.arch, 'x64') # Only needed for x64
+      inputs:
+        targetType: inline
+        script: |
+          .\${{parameters.RepoDirectory}}\\scripts\Install-DotNetTool.ps1 -Name nbgv
+          nbgv cloud 
+
+    - task: PowerShell@2
+      displayName: GenerateMetadataSource.ps1 - 
+      inputs:
+        filePath: '${{ parameters.RepoDirectory }}\scripts\GenerateMetadataSource.ps1'
+        arguments: '-arch $(arch)'
+        errorActionPreference: 'continue'
+        pwsh: true
+
+- stage: build_winmd
+  displayName: "Build WinMD"
+  dependsOn: 'scrape'
+  jobs:
+  - job: build_winmd
+    displayName: Build, test, sign, package winmd
+    workspace:
+      clean: all
+    variables:
+      OutputPackagesDir: $(Build.SourcesDirectory)\${{parameters.RepoDirectory}}\bin\Packages\Release\NuGet
+      ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
+      ob_artifactBaseName: 'NuGetPackages'
+      ob_sdl_binskim_break: true # https://aka.ms/obpipelines/sdl
+    pool:
+      type: windows
+    steps:
+    - template: win32metadata-checkout.yml
+
+    - task: CmdLine@2
+      displayName: Set up VS environment
+      inputs:
+        filename: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat'
+        modifyEnvironment: true
+
+    - task: UseDotNet@2
+      displayName: ⚙ Install .NET SDK
+      inputs:
+        packageType: sdk
+        useGlobalJson: true
+
+      # ESRP Authenticode sign package DLLs
+    - task: UseDotNet@2
+      displayName: Install DotNet 2.1.x for signing tasks
+      inputs:
+        packageType: runtime
+        version: 2.1.x
+
+    - script: dotnet --info
+      displayName: Display .NET SDK/runtime info
+
+    - task: DownloadPipelineArtifact@2
+      displayName: Download x64 generated assets
+      inputs:
+        artifact: 'generated_x64'
+        path: '$(Build.SourcesDirectory)\${{parameters.RepoDirectory}}\generation\WinSDK\obj'
+
+    - task: DownloadPipelineArtifact@2
+      displayName: Download x86 generated assets
+      inputs:
+        artifact: 'generated_x86'
+        path: '$(Build.SourcesDirectory)\${{parameters.RepoDirectory}}\generation\WinSDK\obj'
+
+    - task: DownloadPipelineArtifact@2
+      displayName: Download arm64 generated assets
+      inputs:
+        artifact: 'generated_arm64'
+        path: '$(Build.SourcesDirectory)\${{parameters.RepoDirectory}}\generation\WinSDK\obj'
+
+    - script: dir /s $(Build.SourcesDirectory)\${{parameters.RepoDirectory}}\generation\WinSDK\obj
+      displayName: Print generated files directory ($(Build.SourcesDirectory)\${{parameters.RepoDirectory}}\)
+
+    - task: PowerShell@2
+      displayName: Build metadata binary
+      inputs:
+        filePath: '${{ parameters.RepoDirectory }}\scripts\BuildMetadataBin.ps1'
+        arguments: '-assetsScrapedSeparately'
+        pwsh: true
+
+    # - task: EsrpCodeSigning@1
+    #   displayName: 'Authenticode Sign Binaries in Metadata package'
+    #   inputs:
+    #     ConnectedServiceName: 'Xlang Code Signing'
+    #     FolderPath: '$(Build.SourcesDirectory)\bin'
+    #     Pattern: 'Windows.Win32.winmd'
+    #     signConfigType: 'inlineSignParams'
+    #     inlineOperation: |
+    #       [
+    #         {
+    #           "keyCode": "CP-230012",
+    #           "operationSetCode": "SigntoolSign",
+    #           "parameters": [
+    #             {
+    #               "parameterName": "OpusName",
+    #               "parameterValue": "Microsoft"
+    #             },
+    #             {
+    #               "parameterName": "OpusInfo",
+    #               "parameterValue": "http://www.microsoft.com"
+    #             },
+    #             {
+    #               "parameterName": "PageHash",
+    #               "parameterValue": "/NPH"
+    #             },
+    #             {
+    #               "parameterName": "FileDigest",
+    #               "parameterValue": "/fd sha256"
+    #             },
+    #             {
+    #               "parameterName": "TimeStamp",
+    #               "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+    #             }
+    #           ],
+    #           "toolName": "signtool.exe",
+    #           "toolVersion": "6.2.9304.0"
+    #         }
+    #       ]
+    #     SessionTimeout: '60'
+    #     MaxConcurrency: '50'
+    #     MaxRetryAttempts: '2'
+    #   condition: and(succeeded(), eq(variables['SignFiles'], 'true'), ne(variables['Build.Reason'], 'PullRequest'))
+
+    # - task: EsrpCodeSigning@1
+    #   displayName: Authenticode sign net8.0 binaries in Generator SDK package
+    #   inputs:
+    #     ConnectedServiceName: 'Xlang Code Signing'
+    #     FolderPath: '$(Build.SourcesDirectory)\bin\$(BuildConfiguration)\net8.0'
+    #     Pattern: 'ClangSharpSourceToWinmd.dll,ConstantsScraper.dll,CsvHelper.dll,ICSharpCode.Decompiler.dll,MetadataTasks.dll,MetadataUtils.dll,WinmdUtils.dll'
+    #     signConfigType: 'inlineSignParams'
+    #     inlineOperation: |
+    #       [
+    #         {
+    #           "keyCode": "CP-230012",
+    #           "operationSetCode": "SigntoolSign",
+    #           "parameters": [
+    #             {
+    #               "parameterName": "OpusName",
+    #               "parameterValue": "Microsoft"
+    #             },
+    #             {
+    #               "parameterName": "OpusInfo",
+    #               "parameterValue": "http://www.microsoft.com"
+    #             },
+    #             {
+    #               "parameterName": "PageHash",
+    #               "parameterValue": "/NPH"
+    #             },
+    #             {
+    #               "parameterName": "FileDigest",
+    #               "parameterValue": "/fd sha256"
+    #             },
+    #             {
+    #               "parameterName": "TimeStamp",
+    #               "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+    #             }
+    #           ],
+    #           "toolName": "signtool.exe",
+    #           "toolVersion": "6.2.9304.0"
+    #         }
+    #       ]
+    #     SessionTimeout: '60'
+    #     MaxConcurrency: '50'
+    #     MaxRetryAttempts: '2'
+    #   condition: and(succeeded(), eq(variables['SignFiles'], 'true'), ne(variables['Build.Reason'], 'PullRequest'))
+
+    - task: PowerShell@2
+      displayName: Do packages
+      inputs:
+        filePath: $(Build.SourcesDirectory)\${{parameters.RepoDirectory}}\scripts\DoPackages.ps1
+        arguments: -SkipInstallTools
+        pwsh: true
+
+    - task: PowerShell@2
+      displayName: Do samples
+      inputs:
+        filePath: $(Build.SourcesDirectory)\${{parameters.RepoDirectory}}\scripts\DoSamples.ps1
+        arguments: -SkipInstallTools
+        pwsh: true
+
+    - task: PowerShell@2
+      displayName: Do tests
+      inputs:
+        filePath: $(Build.SourcesDirectory)\${{parameters.RepoDirectory}}\scripts\DoTests.ps1
+        arguments: -SkipInstallTools
+        pwsh: true
+
+    # - task: EsrpCodeSigning@1
+    #   displayName: 'Sign nuget packages'
+    #   inputs:
+    #     ConnectedServiceName: 'Xlang Code Signing'
+    #     FolderPath: '$(OutputPackagesDir)'
+    #     Pattern: '*.nupkg'
+    #     signConfigType: 'inlineSignParams'
+    #     inlineOperation: |
+    #       [
+    #         {
+    #           "KeyCode" : "CP-401405",
+    #           "OperationCode" : "NuGetSign",
+    #           "Parameters" : {},
+    #           "ToolName" : "sign",
+    #           "ToolVersion" : "1.0"
+    #         },
+    #         {
+    #             "KeyCode" : "CP-401405",
+    #             "OperationCode" : "NuGetVerify",
+    #             "Parameters" : {},
+    #             "ToolName" : "sign",
+    #             "ToolVersion" : "1.0"
+    #         }
+    #       ]
+    #     SessionTimeout: '60'
+    #     MaxConcurrency: '50'
+    #     MaxRetryAttempts: '2'
+    #   condition: and(succeeded(), eq(variables['SignFiles'], 'true'), ne(variables['Build.Reason'], 'PullRequest'))
+
+    # - publish: bin/logs
+    #   artifact: build_logs
+    #   displayName: 📢 Publish build logs
+    #   condition: always()
+
+    # - task: PublishPipelineArtifact@1
+    #   displayName: 'Publish NuGet packages to pipeline artifacts'
+    #   inputs:
+    #     targetPath: '$(OutputPackagesDir)'
+    #     artifact: NuGetPackages
+
+    #   # There's a problem on microsoft.visualstudio.com that requires the guid instead of NuGetCommand@2
+    #   # Don't publish if we're using pre-generated source
+    # - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
+    #   displayName: 'NuGet push'
+    #   inputs:
+    #     command: push
+    #     packagesToPush: '$(OutputPackagesDir)/**/*.nupkg;!$(OutputPackagesDir)/**/*.symbols.nupkg'
+    #     publishVstsFeed: 'c1408dcb-1833-4ae4-9af5-1a891a12cc3c'
+    #     allowPackageConflicts: true
+    #   condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))

--- a/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
+++ b/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
@@ -18,6 +18,7 @@ stages:
       matrix:
         x86:
           arch: 'x86'
+          generateMetadataArgs: '-scrapeConstants'
         x64:
           arch: 'x64'
         arm64:
@@ -53,10 +54,10 @@ stages:
           nbgv cloud 
 
     - task: PowerShell@2
-      displayName: GenerateMetadataSource.ps1 - 
+      displayName: GenerateMetadataSource.ps1
       inputs:
         filePath: '${{ parameters.RepoDirectory }}\scripts\GenerateMetadataSource.ps1'
-        arguments: '-arch $(arch)'
+        arguments: '-arch $(arch) $(generateMetadataArgs)'
         errorActionPreference: 'continue'
         pwsh: true
 

--- a/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
+++ b/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
@@ -257,6 +257,20 @@ stages:
     #     MaxRetryAttempts: '2'
     #   condition: and(succeeded(), eq(variables['SignFiles'], 'true'), ne(variables['Build.Reason'], 'PullRequest'))
 
+    # Copy build logs to artifact staging directory
+    - task: CopyFiles@2
+      displayName: 📢 Copy build logs to pipeline artifact staging directory 
+      inputs:
+        SourceFolder: '$(Build.SourcesDirectory)/${{parameters.RepoDirectory}}/bin/logs'
+        TargetFolder: '$(Build.ArtifactStagingDirectory)'
+
+    # Copy nuget package to artifact staging directory
+    - task: CopyFiles@2
+      displayName: Copy NuGet packages to pipeline artifact staging directory
+      inputs:
+        SourceFolder: '$(OutputPackagesDir)'
+        TargetFolder: '$(Build.ArtifactStagingDirectory)'
+
     # - publish: bin/logs
     #   artifact: build_logs
     #   displayName: 📢 Publish build logs

--- a/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
+++ b/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
@@ -8,6 +8,9 @@ parameters:
 - name: BuildConfiguration
   type: string
   default: Release
+- name: OfficialBuild
+  type: boolean
+  default: false
 
 stages:
 - stage: scrape
@@ -129,6 +132,24 @@ stages:
         filePath: '${{ parameters.RepoDirectory }}\scripts\BuildMetadataBin.ps1'
         arguments: '-assetsScrapedSeparately'
         pwsh: true
+
+    - task: onebranch.pipeline.signing@1
+      displayName: '🔒 Onebranch Signing for Binaries in Metadata package'
+      condition: eq(${{ parameters.OfficialBuild }}, 'true')
+      inputs:
+        command: sign
+        signing_profile: external_distribution
+        files_to_sign: 'Windows.Win32.winmd'
+        search_root: $(Build.SourcesDirectory)\bin
+
+    - task: onebranch.pipeline.signing@1
+      displayName: '🔒 Onebranch Signing for net8.0 binaries in Generator SDK package'
+      condition: eq(${{ parameters.OfficialBuild }}, 'true')
+      inputs:
+        command: sign
+        signing_profile: external_distribution
+        files_to_sign: 'ClangSharpSourceToWinmd.dll,ConstantsScraper.dll,CsvHelper.dll,ICSharpCode.Decompiler.dll,MetadataTasks.dll,MetadataUtils.dll,WinmdUtils.dll'
+        search_root: $(Build.SourcesDirectory)\bin\$(BuildConfiguration)\net8.0
 
     # - task: EsrpCodeSigning@1
     #   displayName: 'Authenticode Sign Binaries in Metadata package'

--- a/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
+++ b/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
@@ -82,9 +82,7 @@ stages:
     - task: CmdLine@2
       displayName: Set up VS environment
       inputs:
-        filename: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat'
-        modifyEnvironment: true
-
+        script: 'call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat"'
     - task: UseDotNet@2
       displayName: ⚙ Install .NET SDK
       inputs:

--- a/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
+++ b/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
@@ -26,7 +26,7 @@ stages:
     displayName: "Scrape headers"
     timeoutInMinutes: 60
     variables:
-      ob_outputDirectory: '${{parameters.RepoDirectory}}\generation\WinSDK\obj'
+      ob_outputDirectory: '${{parameters.RepoDirectory}}\generation\WDK\obj'
       ob_artifactBaseName: 'generated'
       ob_artifactSuffix: '_$(arch)'
       ob_sdl_binskim_break: true # https://aka.ms/obpipelines/sdl

--- a/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
+++ b/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
@@ -148,7 +148,14 @@ stages:
       inputs:
         command: sign
         signing_profile: external_distribution
-        files_to_sign: 'ClangSharpSourceToWinmd.dll,ConstantsScraper.dll,CsvHelper.dll,ICSharpCode.Decompiler.dll,MetadataTasks.dll,MetadataUtils.dll,WinmdUtils.dll'
+        files_to_sign: |
+          **/ClangSharpSourceToWinmd.dll;
+          **/ConstantsScraper.dll;
+          **/CsvHelper.dll;
+          **/ICSharpCode.Decompiler.dll;
+          **/MetadataTasks.dll;
+          **/MetadataUtils.dll;
+          **/WinmdUtils.dll;
         search_root: $(Build.SourcesDirectory)\bin\$(BuildConfiguration)\net8.0
 
     # - task: EsrpCodeSigning@1
@@ -249,6 +256,14 @@ stages:
         filePath: $(Build.SourcesDirectory)\${{parameters.RepoDirectory}}\scripts\DoTests.ps1
         pwsh: true
 
+    - task: onebranch.pipeline.signing@1
+      displayName: '🔒 Onebranch Signing for nuget packages'
+      condition: eq(${{ parameters.OfficialBuild }}, 'true')
+      inputs:
+        command: sign
+        signing_profile: external_distribution
+        files_to_sign: '**/*.nupkg'
+        search_root: $(OutputPackagesDir)
     # - task: EsrpCodeSigning@1
     #   displayName: 'Sign nuget packages'
     #   inputs:

--- a/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
+++ b/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
@@ -76,7 +76,7 @@ stages:
     pool:
       type: windows
     steps:
-    - template: win32metadata-checkout.yml
+    - template: wdkmetadata-checkout.yml
 
     - task: CmdLine@2
       displayName: Set up VS environment

--- a/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
+++ b/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
@@ -135,7 +135,6 @@ stages:
       condition: eq(${{ parameters.OfficialBuild }}, 'true')
       inputs:
         command: 'sign'
-        cp_code: 'CP-230012'
         signing_profile: external_distribution
         files_to_sign: 'Windows.Wdk.winmd'
         search_root: $(Build.SourcesDirectory)\${{ parameters.RepoDirectory }}\bin
@@ -157,7 +156,6 @@ stages:
       condition: eq(${{ parameters.OfficialBuild }}, 'true')
       inputs:
         command: sign
-        cp_code: 'CP-401405'
         signing_profile: external_distribution
         files_to_sign: '**/*.nupkg'
         search_root: $(OutputPackagesDir)

--- a/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
+++ b/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
@@ -4,7 +4,7 @@ parameters:
   default: "PullRequest"
 - name: "RepoDirectory"
   type: string
-  default: "wdkmetadata"
+  default: "s" # Shortened repo directory name to keep paths under 260 characters. OneBranch issue where longpath setting doesn't get pushed down to submodules.
 - name: OfficialBuild
   type: boolean
   default: false
@@ -43,15 +43,38 @@ stages:
         packageType: sdk
         useGlobalJson: true
 
-    # TODO - this no longer sets an Azure Devops pipeline build number, OneBranch has a different way of doing that
     - task: PowerShell@2
       displayName: Set build version
       condition: eq(variables.arch, 'x64') # Only needed for x64
       inputs:
         targetType: inline
+        workingDirectory: ${{parameters.RepoDirectory}}
         script: |
-          .\${{parameters.RepoDirectory}}\\scripts\Install-DotNetTool.ps1 -Name nbgv
-          nbgv cloud 
+          .\scripts\Install-DotNetTool.ps1 -Name nbgv
+          nbgv cloud --common-vars
+
+    # Generate the Azure Devops pipeline build number, since nbgv cannot do it for OneBranch pipelines
+    - task: PowerShell@2
+      displayName: Get pipeline run name
+      condition: eq(variables.arch, 'x64')
+      inputs:
+        targetType: inline
+        workingDirectory: ${{parameters.RepoDirectory}}
+        script: |
+          $jsonString = nbgv get-version -f json
+          $nbgvData = $jsonString | ConvertFrom-Json
+          $commitId = $nbgvData.GitCommitId
+          $commitMessage = git log --format=%B -n 1 $commitId
+          Write-Host "Setting pipeline build number to '$(GitBuildVersionSimple) • $commitMessage'"
+          Write-Host "##vso[task.setvariable variable=CommitMessage;]$commitMessage"
+          Write-Host "##vso[task.setvariable variable=CommitId;]$commitId"
+
+    # Set the pipeline build number
+    - task: onebranch.pipeline.version@1
+      condition: eq(variables.arch, 'x64')
+      inputs:
+        system: 'Custom'
+        customVersion: '$(GitBuildVersionSimple) • $(CommitMessage)'
 
     - task: PowerShell@2
       displayName: GenerateMetadataSource.ps1
@@ -60,6 +83,17 @@ stages:
         arguments: '-arch $(arch) $(generateMetadataArgs)'
         errorActionPreference: 'continue'
         pwsh: true
+
+    # Save commit hash for use by the release pipeline    
+    - task: PowerShell@2
+      displayName: Save Source Commit
+      condition: eq(variables.arch, 'x64')
+      inputs:
+        targetType: inline
+        workingDirectory: ${{parameters.RepoDirectory}}
+        script: |
+          Write-Host "Saving Source Commit ID for github release pipeline"
+          "$(CommitId)" | Out-File $(Build.SourcesDirectory)\$(ob_outputDirectory)\SourceCommit.txt
 
 - stage: build_winmd
   displayName: "Build WinMD"
@@ -78,6 +112,8 @@ stages:
       type: windows
     steps:
     - template: wdkmetadata-checkout.yml
+      parameters:
+        RepoDirectory: ${{ parameters.RepoDirectory }}
 
     - task: PowerShell@2
       displayName: Set up VS environment
@@ -144,12 +180,14 @@ stages:
       inputs:
         filePath: $(Build.SourcesDirectory)\${{parameters.RepoDirectory}}\scripts\DoPackages.ps1
         pwsh: true
+        arguments: -SkipInstallTools
 
     - task: PowerShell@2
       displayName: Do tests
       inputs:
         filePath: $(Build.SourcesDirectory)\${{parameters.RepoDirectory}}\scripts\DoTests.ps1
         pwsh: true
+        arguments: -SkipInstallTools
 
     - task: onebranch.pipeline.signing@1
       displayName: '🔒 Onebranch Signing for nuget packages'
@@ -173,17 +211,6 @@ stages:
       inputs:
         SourceFolder: '$(OutputPackagesDir)'
         TargetFolder: '$(Build.ArtifactStagingDirectory)'
-
-    # - publish: bin/logs
-    #   artifact: build_logs
-    #   displayName: 📢 Publish build logs
-    #   condition: always()
-
-    # - task: PublishPipelineArtifact@1
-    #   displayName: 'Publish NuGet packages to pipeline artifacts'
-    #   inputs:
-    #     targetPath: '$(OutputPackagesDir)'
-    #     artifact: NuGetPackages
 
     #   # There's a problem on microsoft.visualstudio.com that requires the guid instead of NuGetCommand@2
     #   # Don't publish if we're using pre-generated source

--- a/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
+++ b/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
@@ -139,110 +139,8 @@ stages:
       inputs:
         command: sign
         signing_profile: external_distribution
-        files_to_sign: 'Windows.Win32.winmd'
+        files_to_sign: 'Windows.Wdk.winmd'
         search_root: $(Build.SourcesDirectory)\${{ parameters.RepoDirectory }}\bin
-
-    - task: onebranch.pipeline.signing@1
-      displayName: '🔒 Onebranch Signing for net8.0 binaries in Generator SDK package'
-      condition: eq(${{ parameters.OfficialBuild }}, 'true')
-      inputs:
-        command: sign
-        signing_profile: external_distribution
-        files_to_sign: |
-          **/ClangSharpSourceToWinmd.dll;
-          **/ConstantsScraper.dll;
-          **/CsvHelper.dll;
-          **/ICSharpCode.Decompiler.dll;
-          **/MetadataTasks.dll;
-          **/MetadataUtils.dll;
-          **/WinmdUtils.dll;
-        search_root: $(Build.SourcesDirectory)\${{ parameters.RepoDirectory }}\bin\$(BuildConfiguration)\net8.0
-
-    # - task: EsrpCodeSigning@1
-    #   displayName: 'Authenticode Sign Binaries in Metadata package'
-    #   inputs:
-    #     ConnectedServiceName: 'Xlang Code Signing'
-    #     FolderPath: '$(Build.SourcesDirectory)\bin'
-    #     Pattern: 'Windows.Win32.winmd'
-    #     signConfigType: 'inlineSignParams'
-    #     inlineOperation: |
-    #       [
-    #         {
-    #           "keyCode": "CP-230012",
-    #           "operationSetCode": "SigntoolSign",
-    #           "parameters": [
-    #             {
-    #               "parameterName": "OpusName",
-    #               "parameterValue": "Microsoft"
-    #             },
-    #             {
-    #               "parameterName": "OpusInfo",
-    #               "parameterValue": "http://www.microsoft.com"
-    #             },
-    #             {
-    #               "parameterName": "PageHash",
-    #               "parameterValue": "/NPH"
-    #             },
-    #             {
-    #               "parameterName": "FileDigest",
-    #               "parameterValue": "/fd sha256"
-    #             },
-    #             {
-    #               "parameterName": "TimeStamp",
-    #               "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-    #             }
-    #           ],
-    #           "toolName": "signtool.exe",
-    #           "toolVersion": "6.2.9304.0"
-    #         }
-    #       ]
-    #     SessionTimeout: '60'
-    #     MaxConcurrency: '50'
-    #     MaxRetryAttempts: '2'
-    #   condition: and(succeeded(), eq(variables['SignFiles'], 'true'), ne(variables['Build.Reason'], 'PullRequest'))
-
-    # - task: EsrpCodeSigning@1
-    #   displayName: Authenticode sign net8.0 binaries in Generator SDK package
-    #   inputs:
-    #     ConnectedServiceName: 'Xlang Code Signing'
-    #     FolderPath: '$(Build.SourcesDirectory)\bin\$(BuildConfiguration)\net8.0'
-    #     Pattern: 'ClangSharpSourceToWinmd.dll,ConstantsScraper.dll,CsvHelper.dll,ICSharpCode.Decompiler.dll,MetadataTasks.dll,MetadataUtils.dll,WinmdUtils.dll'
-    #     signConfigType: 'inlineSignParams'
-    #     inlineOperation: |
-    #       [
-    #         {
-    #           "keyCode": "CP-230012",
-    #           "operationSetCode": "SigntoolSign",
-    #           "parameters": [
-    #             {
-    #               "parameterName": "OpusName",
-    #               "parameterValue": "Microsoft"
-    #             },
-    #             {
-    #               "parameterName": "OpusInfo",
-    #               "parameterValue": "http://www.microsoft.com"
-    #             },
-    #             {
-    #               "parameterName": "PageHash",
-    #               "parameterValue": "/NPH"
-    #             },
-    #             {
-    #               "parameterName": "FileDigest",
-    #               "parameterValue": "/fd sha256"
-    #             },
-    #             {
-    #               "parameterName": "TimeStamp",
-    #               "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-    #             }
-    #           ],
-    #           "toolName": "signtool.exe",
-    #           "toolVersion": "6.2.9304.0"
-    #         }
-    #       ]
-    #     SessionTimeout: '60'
-    #     MaxConcurrency: '50'
-    #     MaxRetryAttempts: '2'
-    #   condition: and(succeeded(), eq(variables['SignFiles'], 'true'), ne(variables['Build.Reason'], 'PullRequest'))
 
     - task: PowerShell@2
       displayName: Do packages
@@ -264,34 +162,6 @@ stages:
         signing_profile: external_distribution
         files_to_sign: '**/*.nupkg'
         search_root: $(OutputPackagesDir)
-    # - task: EsrpCodeSigning@1
-    #   displayName: 'Sign nuget packages'
-    #   inputs:
-    #     ConnectedServiceName: 'Xlang Code Signing'
-    #     FolderPath: '$(OutputPackagesDir)'
-    #     Pattern: '*.nupkg'
-    #     signConfigType: 'inlineSignParams'
-    #     inlineOperation: |
-    #       [
-    #         {
-    #           "KeyCode" : "CP-401405",
-    #           "OperationCode" : "NuGetSign",
-    #           "Parameters" : {},
-    #           "ToolName" : "sign",
-    #           "ToolVersion" : "1.0"
-    #         },
-    #         {
-    #             "KeyCode" : "CP-401405",
-    #             "OperationCode" : "NuGetVerify",
-    #             "Parameters" : {},
-    #             "ToolName" : "sign",
-    #             "ToolVersion" : "1.0"
-    #         }
-    #       ]
-    #     SessionTimeout: '60'
-    #     MaxConcurrency: '50'
-    #     MaxRetryAttempts: '2'
-    #   condition: and(succeeded(), eq(variables['SignFiles'], 'true'), ne(variables['Build.Reason'], 'PullRequest'))
 
     # Copy build logs to artifact staging directory
     - task: CopyFiles@2
@@ -302,7 +172,7 @@ stages:
 
     # Copy nuget package to artifact staging directory
     - task: CopyFiles@2
-      displayName: Copy NuGet packages to pipeline artifact staging directory
+      displayName: 📢 Copy NuGet packages to pipeline artifact staging directory
       inputs:
         SourceFolder: '$(OutputPackagesDir)'
         TargetFolder: '$(Build.ArtifactStagingDirectory)'

--- a/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
+++ b/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
@@ -140,7 +140,7 @@ stages:
         command: sign
         signing_profile: external_distribution
         files_to_sign: 'Windows.Win32.winmd'
-        search_root: $(Build.SourcesDirectory)\bin
+        search_root: $(Build.SourcesDirectory)\${{ parameters.RepoDirectory }}\bin
 
     - task: onebranch.pipeline.signing@1
       displayName: '🔒 Onebranch Signing for net8.0 binaries in Generator SDK package'
@@ -156,7 +156,7 @@ stages:
           **/MetadataTasks.dll;
           **/MetadataUtils.dll;
           **/WinmdUtils.dll;
-        search_root: $(Build.SourcesDirectory)\bin\$(BuildConfiguration)\net8.0
+        search_root: $(Build.SourcesDirectory)\${{ parameters.RepoDirectory }}\bin\$(BuildConfiguration)\net8.0
 
     # - task: EsrpCodeSigning@1
     #   displayName: 'Authenticode Sign Binaries in Metadata package'

--- a/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
+++ b/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
@@ -79,10 +79,20 @@ stages:
     steps:
     - template: wdkmetadata-checkout.yml
 
-    - task: CmdLine@2
+    - task: PowerShell@2
       displayName: Set up VS environment
       inputs:
-        script: 'call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat"'
+        targetType: 'inline'
+        script: |
+          & "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat"
+
+    - task: PowerShell@2
+      displayName: VS environment test
+      inputs:
+        targetType: 'inline'
+        script: |
+          & msbuild
+
     - task: UseDotNet@2
       displayName: ⚙ Install .NET SDK
       inputs:

--- a/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
+++ b/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
@@ -86,13 +86,6 @@ stages:
         script: |
           & "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat"
 
-    - task: PowerShell@2
-      displayName: VS environment test
-      inputs:
-        targetType: 'inline'
-        script: |
-          & msbuild
-
     - task: UseDotNet@2
       displayName: ⚙ Install .NET SDK
       inputs:
@@ -227,14 +220,12 @@ stages:
       displayName: Do packages
       inputs:
         filePath: $(Build.SourcesDirectory)\${{parameters.RepoDirectory}}\scripts\DoPackages.ps1
-        arguments: -SkipInstallTools
         pwsh: true
 
     - task: PowerShell@2
       displayName: Do tests
       inputs:
         filePath: $(Build.SourcesDirectory)\${{parameters.RepoDirectory}}\scripts\DoTests.ps1
-        arguments: -SkipInstallTools
         pwsh: true
 
     # - task: EsrpCodeSigning@1

--- a/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
+++ b/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
@@ -4,7 +4,7 @@ parameters:
   default: "PullRequest"
 - name: "RepoDirectory"
   type: string
-  default: "win32metadata"
+  default: "wdkmetadata"
 - name: BuildConfiguration
   type: string
   default: Release
@@ -32,7 +32,7 @@ stages:
     pool:
       type: windows
     steps:
-    - template: win32metadata-checkout.yml
+    - template: wdkmetadata-checkout.yml
       parameters:
         RepoDirectory: ${{ parameters.RepoDirectory }}
 
@@ -104,21 +104,21 @@ stages:
       displayName: Download x64 generated assets
       inputs:
         artifact: 'generated_x64'
-        path: '$(Build.SourcesDirectory)\${{parameters.RepoDirectory}}\generation\WinSDK\obj'
+        path: '$(Build.SourcesDirectory)\${{parameters.RepoDirectory}}\generation\WDK\obj'
 
     - task: DownloadPipelineArtifact@2
       displayName: Download x86 generated assets
       inputs:
         artifact: 'generated_x86'
-        path: '$(Build.SourcesDirectory)\${{parameters.RepoDirectory}}\generation\WinSDK\obj'
+        path: '$(Build.SourcesDirectory)\${{parameters.RepoDirectory}}\generation\WDK\obj'
 
     - task: DownloadPipelineArtifact@2
       displayName: Download arm64 generated assets
       inputs:
         artifact: 'generated_arm64'
-        path: '$(Build.SourcesDirectory)\${{parameters.RepoDirectory}}\generation\WinSDK\obj'
+        path: '$(Build.SourcesDirectory)\${{parameters.RepoDirectory}}\generation\WDK\obj'
 
-    - script: dir /s $(Build.SourcesDirectory)\${{parameters.RepoDirectory}}\generation\WinSDK\obj
+    - script: dir /s $(Build.SourcesDirectory)\${{parameters.RepoDirectory}}\generation\WDK\obj
       displayName: Print generated files directory ($(Build.SourcesDirectory)\${{parameters.RepoDirectory}}\)
 
     - task: PowerShell@2
@@ -218,13 +218,6 @@ stages:
       displayName: Do packages
       inputs:
         filePath: $(Build.SourcesDirectory)\${{parameters.RepoDirectory}}\scripts\DoPackages.ps1
-        arguments: -SkipInstallTools
-        pwsh: true
-
-    - task: PowerShell@2
-      displayName: Do samples
-      inputs:
-        filePath: $(Build.SourcesDirectory)\${{parameters.RepoDirectory}}\scripts\DoSamples.ps1
         arguments: -SkipInstallTools
         pwsh: true
 

--- a/scripts/DoPackages.ps1
+++ b/scripts/DoPackages.ps1
@@ -12,5 +12,5 @@ if (!$skipInstallTools)
 
 Write-Host "*** Packing packages..." -ForegroundColor Blue
 
-dotnet pack "$PSScriptRoot\..\sources\packages.proj" -c Release --no-build
+dotnet pack "$PSScriptRoot\..\sources\packages.proj" -c Release
 ThrowOnNativeProcessError

--- a/scripts/DoPackages.ps1
+++ b/scripts/DoPackages.ps1
@@ -12,5 +12,5 @@ if (!$skipInstallTools)
 
 Write-Host "*** Packing packages..." -ForegroundColor Blue
 
-dotnet pack "$PSScriptRoot\..\sources\packages.proj" -c Release
+dotnet pack "$PSScriptRoot\..\sources\packages.proj" -c Release --no-build
 ThrowOnNativeProcessError


### PR DESCRIPTION
As part of compliance with updated security requirements, production pipelines must run in a 1ES environment. To do this, pipelines are converting to use OneBranch pipeline templates.

This changes how artifacts are published and the build environment is slightly different, resulting in some small changes to the build files.

As a backup plan, the existing azure pipeline scripts are left in place. These will be removed in the future.