### PR TITLE
Remove commit name from pipeline build number

### DIFF
--- a/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
+++ b/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
@@ -73,7 +73,7 @@ stages:
       condition: eq(variables.arch, 'x64')
       inputs:
         system: 'Custom'
-        customVersion: '$(GitBuildVersionSimple) • $(CommitMessage)'
+        customVersion: '$(GitBuildVersionSimple)'
 
     - task: PowerShell@2
       displayName: GenerateMetadataSource.ps1

--- a/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
+++ b/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
@@ -21,8 +21,10 @@ stages:
           generateMetadataArgs: '-scrapeConstants'
         x64:
           arch: 'x64'
+          generateMetadataArgs: ''
         arm64:
           arch: 'arm64'
+          generateMetadataArgs: ''
     displayName: "Scrape headers"
     timeoutInMinutes: 60
     variables:
@@ -64,9 +66,6 @@ stages:
           $jsonString = nbgv get-version -f json
           $nbgvData = $jsonString | ConvertFrom-Json
           $commitId = $nbgvData.GitCommitId
-          $commitMessage = git log --format=%B -n 1 $commitId
-          Write-Host "Setting pipeline build number to '$(GitBuildVersionSimple) • $commitMessage'"
-          Write-Host "##vso[task.setvariable variable=CommitMessage;]$commitMessage"
           Write-Host "##vso[task.setvariable variable=CommitId;]$commitId"
 
     # Set the pipeline build number


### PR DESCRIPTION
Commit messages are often too long and have disallowed characters, which interfered with the pipeline running. They arguably do not belong in the ADO pipeline build number anyways. This change removes them.