### PR TITLE
Move wdkmetadata to a more secure nuget feed

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -3,7 +3,7 @@
   <packageSources>
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="Win32Metadata-Dependencies" value="https://pkgs.dev.azure.com/shine-oss/Win32Metadata/_packaging/Win32Metadata-Dependencies/nuget/v3/index.json" protocolVersion="3"/>
   </packageSources>
   <disabledPackageSources>
     <clear />


### PR DESCRIPTION
Rather than pulling directly from nuget.org, the build will now pull from a managed public nuget feed. The new nuget feed still upstreams to nuget.org and caches any package pulled from nuget.org. The major difference in operation is that the first time that a new package or version is pulled from an upstream source, it requires authentication by a Microsoft employee.