### PR TITLE
Specify NuGet configfile for dotnet tool

### DIFF
--- a/scripts/CommonUtils.ps1
+++ b/scripts/CommonUtils.ps1
@@ -71,7 +71,7 @@ function Install-BuildTools
         & dotnet clean "$rootDir\buildtools"
     }
 
-    & dotnet build "$rootDir\buildtools" -c Release "-bl:$PSScriptRoot\..\bin\logs\buildtools.binlog"
+    & dotnet build "$rootDir\buildtools" -c Release "-bl:$PSScriptRoot\..\bin\logs\buildtools.binlog" --verbosity detailed
     ThrowOnNativeProcessError
 
     Install-VsDevShell

--- a/scripts/CommonUtils.ps1
+++ b/scripts/CommonUtils.ps1
@@ -64,7 +64,7 @@ function Install-BuildTools
 {
     Param([switch]$Clean)
 
-    & "$PSScriptRoot\Install-DotNetTool" -Name nbgv
+    & "$PSScriptRoot\Install-DotNetTool" -Name nbgv -NuGetConfigFile "$rootDir\nuget.Config"
 
     if ($Clean.IsPresent)
     {

--- a/scripts/GenerateMetadataSource.ps1
+++ b/scripts/GenerateMetadataSource.ps1
@@ -23,5 +23,5 @@ else
     $target = "ScrapeHeaders"
 }
 
-dotnet build "$wdkProjectRoot" -c Release -p:ScanArch=$arch -t:$target "-bl:$PSScriptRoot\..\bin\logs\GenerateMetadataSources.binlog" --verbosity detailed
+dotnet build "$wdkProjectRoot" -c Release -p:ScanArch=$arch -t:$target "-bl:$PSScriptRoot\..\bin\logs\GenerateMetadataSources.binlog"
 ThrowOnNativeProcessError

--- a/scripts/GenerateMetadataSource.ps1
+++ b/scripts/GenerateMetadataSource.ps1
@@ -23,5 +23,5 @@ else
     $target = "ScrapeHeaders"
 }
 
-dotnet build "$wdkProjectRoot" -c Release -p:ScanArch=$arch -t:$target "-bl:$PSScriptRoot\..\bin\logs\GenerateMetadataSources.binlog"
+dotnet build "$wdkProjectRoot" -c Release -p:ScanArch=$arch -t:$target "-bl:$PSScriptRoot\..\bin\logs\GenerateMetadataSources.binlog" --verbosity detailed
 ThrowOnNativeProcessError

--- a/scripts/Install-DotNetTool.ps1
+++ b/scripts/Install-DotNetTool.ps1
@@ -5,7 +5,7 @@ if ($Version -ne '')
     $installed = & dotnet tool list -g | select-string -Pattern "$Name\s+$Version"
     if ($installed -eq $null)
     {
-        & dotnet tool update --global $Name --version $Version
+        & dotnet tool update --global $Name --version $Version --verbosity d
     }
 }
 else
@@ -13,6 +13,6 @@ else
     $installed = & dotnet tool list -g | select-string -Pattern "$Name"
     if ($installed -eq $null)
     {
-        & dotnet tool update --global $Name
+        & dotnet tool update --global $Name --verbosity d
     }
 }

--- a/scripts/Install-DotNetTool.ps1
+++ b/scripts/Install-DotNetTool.ps1
@@ -1,11 +1,15 @@
-Param ([string] $Name, [string] $Version = '')
+Param ([string] $Name, [string] $Version = '', [string] $NuGetConfigFile)
+
+if (-not $NuGetConfigFile -or -not (Test-Path -Path $NuGetConfigFile -PathType Leaf)) {
+    throw "NuGetConfigFile is either null or not a valid file path."
+}
 
 if ($Version -ne '')
 {
     $installed = & dotnet tool list -g | select-string -Pattern "$Name\s+$Version"
     if ($installed -eq $null)
     {
-        & dotnet tool update --global $Name --version $Version --verbosity d
+        & dotnet tool update --global $Name --version $Version --configfile $NuGetConfigFile --verbosity d
     }
 }
 else
@@ -13,6 +17,6 @@ else
     $installed = & dotnet tool list -g | select-string -Pattern "$Name"
     if ($installed -eq $null)
     {
-        & dotnet tool update --global $Name --verbosity d
+        & dotnet tool update --global $Name --configfile $NuGetConfigFile --verbosity d
     }
 }

--- a/scripts/Install-DotNetTool.ps1
+++ b/scripts/Install-DotNetTool.ps1
@@ -9,7 +9,7 @@ if ($Version -ne '')
     $installed = & dotnet tool list -g | select-string -Pattern "$Name\s+$Version"
     if ($installed -eq $null)
     {
-        & dotnet tool update --global $Name --version $Version --configfile $NuGetConfigFile --verbosity d
+        & dotnet tool update --global $Name --version $Version --configfile $NuGetConfigFile
     }
 }
 else
@@ -17,6 +17,6 @@ else
     $installed = & dotnet tool list -g | select-string -Pattern "$Name"
     if ($installed -eq $null)
     {
-        & dotnet tool update --global $Name --configfile $NuGetConfigFile --verbosity d
+        & dotnet tool update --global $Name --configfile $NuGetConfigFile
     }
 }


### PR DESCRIPTION
**Issue:**
Despite having a NuGet.config file in the root of the repository dotnet tool was pulling from NuGet.org. The expected behavior is all NuGet packages from the feed specified in NuGet.config.

**Fix:**
Pass the [configfile](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-update#options) argument to `dotnet tool update` so packages are pulled from source specified in NuGet.config file.

**How verified:**
Ran PR build with verbose logging enabled to confirm packages are being pulled from proper source specified in NuGet.config.
<img width="1057" alt="image" src="https://github.com/user-attachments/assets/64e973ae-40db-4f19-b078-0495b5c8221b">


