### PR TITLE
Update other callers to Install-DotNetTool

### DIFF
--- a/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
+++ b/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
@@ -53,7 +53,7 @@ stages:
         workingDirectory: ${{parameters.RepoDirectory}}
         script: |
           .\scripts\Install-DotNetTool.ps1 -Name nbgv
-          nbgv cloud --common-vars
+          nbgv cloud --common-vars -NuGetConfigFile "${{parameters.RepoDirectory}}\nuget.config"
 
     # Generate the Azure Devops pipeline build number, since nbgv cannot do it for OneBranch pipelines
     - task: PowerShell@2

--- a/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
+++ b/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
@@ -52,8 +52,8 @@ stages:
         targetType: inline
         workingDirectory: ${{parameters.RepoDirectory}}
         script: |
-          .\scripts\Install-DotNetTool.ps1 -Name nbgv
-          nbgv cloud --common-vars -NuGetConfigFile "${{parameters.RepoDirectory}}\nuget.config"
+          .\scripts\Install-DotNetTool.ps1 -Name nbgv -NuGetConfigFile "${{parameters.RepoDirectory}}\nuget.config"
+          nbgv cloud --common-vars 
 
     # Generate the Azure Devops pipeline build number, since nbgv cannot do it for OneBranch pipelines
     - task: PowerShell@2

--- a/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
+++ b/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
@@ -52,7 +52,7 @@ stages:
         targetType: inline
         workingDirectory: ${{parameters.RepoDirectory}}
         script: |
-          .\scripts\Install-DotNetTool.ps1 -Name nbgv -NuGetConfigFile "$(Build.SourcesDirectory)\nuget.config"
+          .\scripts\Install-DotNetTool.ps1 -Name nbgv -NuGetConfigFile '$(Build.SourcesDirectory)\${{parameters.RepoDirectory}}\nuget.config'
           nbgv cloud --common-vars 
 
     # Generate the Azure Devops pipeline build number, since nbgv cannot do it for OneBranch pipelines

--- a/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
+++ b/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
@@ -52,7 +52,7 @@ stages:
         targetType: inline
         workingDirectory: ${{parameters.RepoDirectory}}
         script: |
-          .\scripts\Install-DotNetTool.ps1 -Name nbgv -NuGetConfigFile "${{parameters.RepoDirectory}}\nuget.config"
+          .\scripts\Install-DotNetTool.ps1 -Name nbgv -NuGetConfigFile "$(Build.SourcesDirectory)\nuget.config"
           nbgv cloud --common-vars 
 
     # Generate the Azure Devops pipeline build number, since nbgv cannot do it for OneBranch pipelines

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ jobs:
     inputs:
       targetType: inline
       script: |
-        .\scripts\Install-DotNetTool.ps1 -Name nbgv -NuGetConfigFile '$(Build.SourcesDirectory)\nuget.config'
+        .\scripts\Install-DotNetTool.ps1 -Name nbgv -NuGetConfigFile "$(Build.SourcesDirectory)\nuget.config"
         nbgv cloud
 
   - task: PowerShell@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ jobs:
     inputs:
       targetType: inline
       script: |
-        .\scripts\Install-DotNetTool.ps1 -Name nbgv
+        .\scripts\Install-DotNetTool.ps1 -Name nbgv -NuGetConfigFile '$(Build.SourcesDirectory)\nuget.config'
         nbgv cloud
 
   - task: PowerShell@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ jobs:
     inputs:
       targetType: inline
       script: |
-        .\scripts\Install-DotNetTool.ps1 -Name nbgv -NuGetConfigFile "$(Build.SourcesDirectory)\nuget.config"
+        .\scripts\Install-DotNetTool.ps1 -Name nbgv -NuGetConfigFile '$(Build.SourcesDirectory)\${{parameters.RepoDirectory}}\nuget.config'
         nbgv cloud
 
   - task: PowerShell@2

--- a/scripts/CommonUtils.ps1
+++ b/scripts/CommonUtils.ps1
@@ -71,7 +71,7 @@ function Install-BuildTools
         & dotnet clean "$rootDir\buildtools"
     }
 
-    & dotnet build "$rootDir\buildtools" -c Release "-bl:$PSScriptRoot\..\bin\logs\buildtools.binlog" --verbosity detailed
+    & dotnet build "$rootDir\buildtools" -c Release "-bl:$PSScriptRoot\..\bin\logs\buildtools.binlog"
     ThrowOnNativeProcessError
 
     Install-VsDevShell

--- a/scripts/Install-DotNetTool.ps1
+++ b/scripts/Install-DotNetTool.ps1
@@ -1,7 +1,11 @@
 Param ([string] $Name, [string] $Version = '', [string] $NuGetConfigFile)
 
-if (-not $NuGetConfigFile -or -not (Test-Path -Path $NuGetConfigFile -PathType Leaf)) {
-    throw "NuGetConfigFile is either null or not a valid file path."
+if (-not $NuGetConfigFile) {
+    throw "NuGetConfigFile is null must be a valid file path to NuGet.config file."
+}
+
+if (-not (Test-Path -Path $NuGetConfigFile -PathType Leaf) {
+	throw "NuGetConfigFile file wasn't found at supplied path valid path to NuGet.config file."
 }
 
 if ($Version -ne '')

--- a/scripts/Install-DotNetTool.ps1
+++ b/scripts/Install-DotNetTool.ps1
@@ -1,11 +1,11 @@
 Param ([string] $Name, [string] $Version = '', [string] $NuGetConfigFile)
 
 if (-not $NuGetConfigFile) {
-    throw "NuGetConfigFile is null must be a valid file path to NuGet.config file."
+    throw "NuGetConfigFile is null. NuGetConfigFile must be a valid file path to a NuGet.config file."
 }
 
 if (-not (Test-Path -Path $NuGetConfigFile -PathType Leaf)) {
-	throw "NuGetConfigFile file wasn't found at supplied path valid path to NuGet.config file."
+	throw "NuGetConfigFile file wasn't found at supplied path. NuGetConfigFile must be a valid file path to a NuGet.config file."
 }
 
 if ($Version -ne '')

--- a/scripts/Install-DotNetTool.ps1
+++ b/scripts/Install-DotNetTool.ps1
@@ -4,7 +4,7 @@ if (-not $NuGetConfigFile) {
     throw "NuGetConfigFile is null must be a valid file path to NuGet.config file."
 }
 
-if (-not (Test-Path -Path $NuGetConfigFile -PathType Leaf) {
+if (-not (Test-Path -Path $NuGetConfigFile -PathType Leaf)) {
 	throw "NuGetConfigFile file wasn't found at supplied path valid path to NuGet.config file."
 }
 


### PR DESCRIPTION
**Issue:**
Install-DotNetTool is called in the x64 build to set the version. Previous check-in #79 missed this call and broke x64 builds.  

**What's changed:**
This change adds the NuGetConfigFile param to the call.  I've also updated the messaging to better let the caller of Install-DotNetTool know when the parameter is missed or the path to NuGet.config doesn't exist.

**How verified:**
Ran the PR build and confirmed passed. Confirmed PR build received a version number as well which is what the nbgv tool is meant to provide.