### PR TITLE
Update and centralize ngbv

### DIFF
--- a/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
+++ b/AzurePipelinesTemplates/wdkmetadata-onebranch.yml
@@ -52,7 +52,7 @@ stages:
         targetType: inline
         workingDirectory: ${{parameters.RepoDirectory}}
         script: |
-          .\scripts\Install-DotNetTool.ps1 -Name nbgv -NuGetConfigFile '$(Build.SourcesDirectory)\${{parameters.RepoDirectory}}\nuget.config'
+          .\scripts\Install-ngbv.ps1 -NuGetConfigFile '$(Build.SourcesDirectory)\${{parameters.RepoDirectory}}\nuget.config'
           nbgv cloud --common-vars 
 
     # Generate the Azure Devops pipeline build number, since nbgv cannot do it for OneBranch pipelines

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ jobs:
     inputs:
       targetType: inline
       script: |
-        .\scripts\Install-DotNetTool.ps1 -Name nbgv -NuGetConfigFile '$(Build.SourcesDirectory)\${{parameters.RepoDirectory}}\nuget.config'
+        .\scripts\Install-ngbv.ps1 -NuGetConfigFile '$(Build.SourcesDirectory)\${{parameters.RepoDirectory}}\nuget.config'
         nbgv cloud
 
   - task: PowerShell@2

--- a/scripts/CommonUtils.ps1
+++ b/scripts/CommonUtils.ps1
@@ -64,7 +64,7 @@ function Install-BuildTools
 {
     Param([switch]$Clean)
 
-    & "$PSScriptRoot\Install-ngbv.ps1" -Name nbgv -Version 3.7.115 -NuGetConfigFile "$rootDir\nuget.Config"
+    & "$PSScriptRoot\Install-ngbv.ps1" -NuGetConfigFile "$rootDir\nuget.Config"
 
     if ($Clean.IsPresent)
     {

--- a/scripts/CommonUtils.ps1
+++ b/scripts/CommonUtils.ps1
@@ -64,7 +64,7 @@ function Install-BuildTools
 {
     Param([switch]$Clean)
 
-    & "$PSScriptRoot\Install-DotNetTool" -Name nbgv -NuGetConfigFile "$rootDir\nuget.Config"
+    & "$PSScriptRoot\Install-ngbv.ps1" -Name nbgv -Version 3.7.115 -NuGetConfigFile "$rootDir\nuget.Config"
 
     if ($Clean.IsPresent)
     {

--- a/scripts/Install-ngbv.ps1
+++ b/scripts/Install-ngbv.ps1
@@ -1,0 +1,11 @@
+# Centralized script to install the nbgv tool using the Install-DotNetTool.ps1 script.
+# When switching to a newer version of nbgv tool, update the version number in this script
+# and make sure the Azure Artificats feed: https://pkgs.dev.azure.com/shine-oss/Win32Metadata/_packaging/Win32Metadata-Dependencies/nuget/v3/index.json
+# has the new version available.
+Param ([string] $NuGetConfigFile)
+
+if (-not $NuGetConfigFile) {
+    throw "NuGetConfigFile is null. NuGetConfigFile must be a valid file path to a NuGet.config file."
+}
+
+& "$PSScriptRoot\Install-DotNetTool.ps1" -Name nbgv -Version 3.7.115 -NuGetConfigFile $NuGetConfigFile


### PR DESCRIPTION
This pull request Fixes #85 includes several changes to the installation scripts and pipeline configurations to standardize the installation of the `nbgv` tool using a new centralized script. The most important changes include updating the pipeline configuration files to use the new script and adding the new script itself.

Updates to pipeline configurations:

* [`AzurePipelinesTemplates/wdkmetadata-onebranch.yml`](diffhunk://#diff-13b7ded7cd712201d2ce22b9068916c5fd24e3522b3a6a567ae94675eded4addL55-R55): Updated the script to use `Install-ngbv.ps1` instead of `Install-DotNetTool.ps1`.
* [`azure-pipelines.yml`](diffhunk://#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5L36-R36): Updated the script to use `Install-ngbv.ps1` instead of `Install-DotNetTool.ps1`.

Updates to scripts:

* [`scripts/CommonUtils.ps1`](diffhunk://#diff-3cffed3ca0c73656a3d863387bce402cb6bcba7d5a29ccef2f3596104350cafaL67-R67): Modified the `Install-BuildTools` function to use `Install-ngbv.ps1` with a specified version.
* [`scripts/Install-ngbv.ps1`](diffhunk://#diff-6a4aaba6f670af4db47406946ae5a94810fc6bf2a1f60c7e03a368ee51e5a805R1-R11): Added a new script to centralize the installation of the `nbgv` tool, including version management and error handling for the `NuGetConfigFile` parameter.