### PR TITLE
Update Windows SDK requirement from 22000 to 26100

### DIFF
--- a/scripts/Get-RequiredWorkloads.ps1
+++ b/scripts/Get-RequiredWorkloads.ps1
@@ -6,4 +6,4 @@
 'Microsoft.NetCore.Component.SDK'
 'Microsoft.VisualStudio.Component.VC.Tools.ARM64'
 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64'
-'Microsoft.VisualStudio.Component.Windows11SDK.22000'
+'Microsoft.VisualStudio.Component.Windows11SDK.26100'


### PR DESCRIPTION
Fixes pipeline breakage